### PR TITLE
2D intersection shaping example

### DIFF
--- a/quest/flat_eight_point_star.stl
+++ b/quest/flat_eight_point_star.stl
@@ -1,0 +1,114 @@
+solid flat_eight_star
+  facet normal 0 0 1
+    outer loop
+      vertex 0.25 0 0
+      vertex 0.5 0.25 0
+      vertex 0.25 0.25 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.5 0.25 0
+      vertex 0.75 0 0
+      vertex 0.75 0.25 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.75 0.25 0
+      vertex 1.0 0.25 0
+      vertex 0.75 0.5 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.75 0.5 0
+      vertex 1.0 0.75 0
+      vertex 0.75 0.75 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.5 0.75 0
+      vertex 0.75 0.75 0
+      vertex 0.75 1.0 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.25 0.75 0
+      vertex 0.5 0.75 0
+      vertex 0.25 1.0 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.25 0.5 0
+      vertex 0.25 0.75 0
+      vertex 0 0.75 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0.25 0
+      vertex 0.25 0.25 0
+      vertex 0.25 0.5 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.25 0.25 0
+      vertex 0.5 0.25 0
+      vertex 0.25 0.5 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.25 0.5 0
+      vertex 0.5 0.25 0
+      vertex 0.5 0.5 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.5 0.25 0
+      vertex 0.75 0.25 0
+      vertex 0.5 0.5 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.5 0.5 0
+      vertex 0.75 0.25 0
+      vertex 0.75 0.5 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.5 0.5 0
+      vertex 0.75 0.5 0
+      vertex 0.5 0.75 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.5 0.75 0
+      vertex 0.75 0.5 0
+      vertex 0.75 0.75 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.25 0.5 0
+      vertex 0.5 0.5 0
+      vertex 0.25 0.75 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.25 0.75 0
+      vertex 0.5 0.5 0
+      vertex 0.5 0.75 0
+    endloop
+  endfacet
+endsolid flat_eight_star

--- a/shaping/flat_star.yaml
+++ b/shaping/flat_star.yaml
@@ -1,0 +1,8 @@
+dimensions: 2
+units: cm
+shapes:
+  - name: flat_eight_point_star 
+    material: steel
+    geometry:
+      format: stl 
+      path: ../quest/flat_eight_point_star.stl


### PR DESCRIPTION
This PR:
- Adds a simple 2D (0 for the z-component) `stl` mesh of a star for 2D intersection shaping.
  -You can see what the star looks like by going to "Files changed" --> quest/flat_eight_point_star.stl --> "View file" 